### PR TITLE
set row height attributes from new ws[!rows] property

### DIFF
--- a/bits/67_wsxml.js
+++ b/bits/67_wsxml.js
@@ -290,7 +290,14 @@ function write_ws_xml_data(ws, opts, idx, wb) {
 			if(ws[ref] === undefined) continue;
 			if((cell = write_ws_xml_cell(ws[ref], ref, ws, opts, idx, wb)) != null) r.push(cell);
 		}
-		if(r.length > 0) o[o.length] = (writextag('row', r.join(""), {r:rr}));
+		if (r.length > 0) {
+			var attributes = {r: rr}
+			if (ws['!rows'] && ws['!rows'][R] && ws['!rows'][R].height) {
+				attributes.ht = ws['!rows'][R].height
+				attributes.customHeight = '1'
+			}
+			o[o.length] = (writextag('row', r.join(''), attributes))
+		}
 	}
 	return o.join("");
 }

--- a/xlsx.js
+++ b/xlsx.js
@@ -7828,7 +7828,14 @@ function write_ws_xml_data(ws, opts, idx, wb) {
 			if(ws[ref] === undefined) continue;
 			if((cell = write_ws_xml_cell(ws[ref], ref, ws, opts, idx, wb)) != null) r.push(cell);
 		}
-		if(r.length > 0) o[o.length] = (writextag('row', r.join(""), {r:rr}));
+		if (r.length > 0) {
+			var attributes = {r: rr}
+			if (ws['!rows'] && ws['!rows'][R] && ws['!rows'][R].height) {
+				attributes.ht = ws['!rows'][R].height
+				attributes.customHeight = '1'
+			}
+			o[o.length] = (writextag('row', r.join(''), attributes))
+		}
 	}
 	return o.join("");
 }


### PR DESCRIPTION
The main js-xlsx project has started (slowly) cherry-picking format features from the fork (protobi) that this fork is based off of.  But I suspect it will be a long time, if ever until everything we needs gets merged back.  
So, if we want row height to be set this is needed.  I intend to submit a PR to https://github.com/protobi/js-xlsx/issues/25 as well and see if it gets merged in.

(Don't delete this branch)